### PR TITLE
Fail when parsing openapi 3.1

### DIFF
--- a/spektor-lib/spektor-parser/src/main/java/io/github/vooft/spektor/parser/SpektorFile.kt
+++ b/spektor-lib/spektor-parser/src/main/java/io/github/vooft/spektor/parser/SpektorFile.kt
@@ -3,6 +3,7 @@ package io.github.vooft.spektor.parser
 import io.github.vooft.spektor.model.SpektorPath
 import io.github.vooft.spektor.model.SpektorType
 import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.SpecVersion
 import io.swagger.v3.parser.OpenAPIV3Parser
 import io.swagger.v3.parser.core.models.ParseOptions
 import java.nio.file.Path
@@ -13,6 +14,7 @@ class SpektorFile(private val file: Path, allRefs: MutableSet<SpektorType.Ref>) 
 
     init {
         require(file.isAbsolute) { "File path must be absolute: $file" }
+        require(parsed.specVersion == SpecVersion.V30) { "Only OpenAPI 3.0 is supported, but got ${parsed.specVersion} in file $file" }
     }
 
     private val typeResolver = SpektorTypeResolver(file, allRefs)


### PR DESCRIPTION
Currently there is a difference in how 3.0 vs 3.1 being parsed, we only support 3.0 at the moment.