### PR TITLE
Generate object when an oneOf variant has no properties besides the discriminator

### DIFF
--- a/spektor-lib/spektor-codegen/src/main/kotlin/io/github/vooft/spektor/codegen/codegen/SpektorTypeDtoCodegen.kt
+++ b/spektor-lib/spektor-codegen/src/main/kotlin/io/github/vooft/spektor/codegen/codegen/SpektorTypeDtoCodegen.kt
@@ -59,13 +59,13 @@ class SpektorTypeDtoCodegen(
             )
 
         for (variant in resolvedVariants) {
-            builder.addType(generateVariantDataClass(variant, sealedClassName, oneOfType.discriminatorPropertyName))
+            builder.addType(generateVariantType(variant, sealedClassName, oneOfType.discriminatorPropertyName))
         }
 
         return builder.build()
     }
 
-    private fun generateVariantDataClass(
+    private fun generateVariantType(
         variant: SpektorType.OneOf.ResolvedVariant,
         sealedParent: ClassName,
         discriminatorPropertyName: String,
@@ -82,14 +82,23 @@ class SpektorTypeDtoCodegen(
                 )
             }
 
-        return TypeSpec.classBuilder(config.classNameFor(variant.ref).simpleName)
+        val variantName = config.classNameFor(variant.ref).simpleName
+        val serialNameAnnotation = AnnotationSpec.builder(SERIAL_NAME_ANNOTATION)
+            .addMember("%S", variant.discriminatorValue)
+            .build()
+
+        if (fields.isEmpty()) {
+            return TypeSpec.objectBuilder(variantName)
+                .addAnnotation(SERIALIZABLE_ANNOTATION)
+                .addAnnotation(serialNameAnnotation)
+                .addSuperinterface(sealedParent)
+                .build()
+        }
+
+        return TypeSpec.classBuilder(variantName)
             .addModifiers(KModifier.DATA)
             .addAnnotation(SERIALIZABLE_ANNOTATION)
-            .addAnnotation(
-                AnnotationSpec.builder(SERIAL_NAME_ANNOTATION)
-                    .addMember("%S", variant.discriminatorValue)
-                    .build()
-            )
+            .addAnnotation(serialNameAnnotation)
             .addSuperinterface(sealedParent)
             .primaryConstructor(
                 FunSpec.constructorBuilder()

--- a/spektor-lib/spektor-codegen/src/test/kotlin/io/github/vooft/spektor/codegen/SpektorCodegenOneOfTest.kt
+++ b/spektor-lib/spektor-codegen/src/test/kotlin/io/github/vooft/spektor/codegen/SpektorCodegenOneOfTest.kt
@@ -1,11 +1,14 @@
 package io.github.vooft.spektor.codegen
 
 import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeSpec
 import io.github.vooft.spektor.codegen.common.SpektorCodegenConfig
 import io.github.vooft.spektor.parser.SpektorParser
+import io.github.vooft.spektor.test.TestFiles.listEventFile
 import io.github.vooft.spektor.test.TestFiles.listOwnerFile
 import io.github.vooft.spektor.test.TestFiles.rootPath
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import org.junit.jupiter.api.Test
@@ -99,5 +102,23 @@ class SpektorCodegenOneOfTest {
         val business = ownerType.typeSpecs.single { it.name == "BusinessDto" }
         val businessAnnotations = business.annotations.map { it.typeName.toString() }
         businessAnnotations shouldContain "kotlinx.serialization.SerialName"
+    }
+
+    @Test
+    fun `should generate object for variant with no fields besides discriminator`() {
+        val schema = parser.parse(listOf(listEventFile))
+        val context = codegen.generate(schema)
+
+        val eventType = context.generatedTypeSpecs.values
+            .single { it.className.simpleName == "EventDto" }
+            .type
+
+        val pingEvent = eventType.typeSpecs.single { it.name == "PingEventDto" }
+        pingEvent.modifiers shouldNotContain KModifier.DATA
+        pingEvent.kind shouldBe TypeSpec.Kind.OBJECT
+        pingEvent.propertySpecs.map { it.name } shouldNotContain "type"
+
+        val clickEvent = eventType.typeSpecs.single { it.name == "ClickEventDto" }
+        clickEvent.modifiers shouldContain KModifier.DATA
     }
 }

--- a/spektor-lib/spektor-testdata/src/main/kotlin/io/github/vooft/spektor/test/TestFiles.kt
+++ b/spektor-lib/spektor-testdata/src/main/kotlin/io/github/vooft/spektor/test/TestFiles.kt
@@ -27,4 +27,6 @@ object TestFiles {
     val moneyModelFile: Path = rootPath.resolve("models/money.yaml")
     val countryPricesModelFile: Path = rootPath.resolve("models/country-prices.yaml")
     val ownerModelFile: Path = rootPath.resolve("models/owner.yaml")
+    val listEventFile: Path = rootPath.resolve("api/list-event.yaml")
+    val eventModelFile: Path = rootPath.resolve("models/event.yaml")
 }

--- a/spektor-lib/spektor-testdata/src/test/resources/api/list-event.yaml
+++ b/spektor-lib/spektor-testdata/src/test/resources/api/list-event.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.1
+info:
+  title: Event API
+  version: 1.0.0
+paths:
+  /event:
+    get:
+      tags:
+        - Event
+      operationId: list
+      responses:
+        200:
+          description: List is returned
+          content:
+            application/json:
+              schema:
+                $ref: '../models/event.yaml#/components/schemas/Event'

--- a/spektor-lib/spektor-testdata/src/test/resources/models/event.yaml
+++ b/spektor-lib/spektor-testdata/src/test/resources/models/event.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.1
+info:
+  title: Event Models
+  version: 1.0.0
+paths: { }
+components:
+  schemas:
+    Event:
+      oneOf:
+        - $ref: '#/components/schemas/ClickEvent'
+        - $ref: '#/components/schemas/PingEvent'
+      discriminator:
+        propertyName: type
+        mapping:
+          CLICK: '#/components/schemas/ClickEvent'
+          PING: '#/components/schemas/PingEvent'
+    ClickEvent:
+      type: object
+      properties:
+        type:
+          type: string
+        x:
+          type: integer
+        y:
+          type: integer
+      required:
+        - type
+        - x
+        - y
+    PingEvent:
+      type: object
+      properties:
+        type:
+          type: string
+      required:
+        - type

--- a/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/apis/EventRestService.kt
+++ b/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/apis/EventRestService.kt
@@ -1,0 +1,19 @@
+package io.github.vooft.spektor.sample.apis
+
+import io.ktor.server.application.ApplicationCall
+import spektor.example.api.event.EventServerApi
+import spektor.example.api.event.EventServerApi.ListResponse
+import spektor.example.models.event.EventDto
+import spektor.example.models.event.EventsListDto
+
+class EventRestService : EventServerApi {
+    private val events = mutableListOf<EventDto>(
+        EventDto.ClickEventDto(
+            x = 10,
+            y = 20,
+        ),
+        EventDto.PingEventDto,
+    )
+
+    override suspend fun list(call: ApplicationCall): ListResponse = ListResponse.ok(EventsListDto(events = events))
+}

--- a/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/ktor/DependencyInjection.kt
+++ b/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/ktor/DependencyInjection.kt
@@ -2,6 +2,7 @@ package io.github.vooft.spektor.sample.ktor
 
 import io.github.vooft.spektor.sample.apis.AuthorRestService
 import io.github.vooft.spektor.sample.apis.BookRestService
+import io.github.vooft.spektor.sample.apis.EventRestService
 import io.github.vooft.spektor.sample.apis.OwnerRestService
 import io.github.vooft.spektor.sample.repository.AuthorRepository
 import io.github.vooft.spektor.sample.repository.BookRepository
@@ -9,6 +10,7 @@ import io.ktor.server.application.Application
 import io.ktor.server.plugins.di.dependencies
 import spektor.example.api.author.AuthorRoutes
 import spektor.example.api.book.BookRoutes
+import spektor.example.api.event.EventRoutes
 import spektor.example.api.owner.OwnerRoutes
 
 fun Application.configureDependencyInjection() {
@@ -19,9 +21,11 @@ fun Application.configureDependencyInjection() {
         provide { AuthorRestService(resolve(), resolve()) }
         provide { BookRestService(resolve(), resolve()) }
         provide { OwnerRestService() }
+        provide { EventRestService() }
 
         provide { AuthorRoutes(resolve()) }
         provide { BookRoutes(resolve()) }
         provide { OwnerRoutes(resolve()) }
+        provide { EventRoutes(resolve()) }
     }
 }

--- a/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/ktor/Routing.kt
+++ b/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/ktor/Routing.kt
@@ -6,12 +6,14 @@ import io.ktor.server.plugins.di.dependencies
 import io.ktor.server.routing.routing
 import spektor.example.api.author.AuthorRoutes
 import spektor.example.api.book.BookRoutes
+import spektor.example.api.event.EventRoutes
 import spektor.example.api.owner.OwnerRoutes
 
 fun Application.configureRouting() {
     val authorRoutes: AuthorRoutes by dependencies
     val bookRoutes: BookRoutes by dependencies
     val ownerRoutes: OwnerRoutes by dependencies
+    val eventRoutes: EventRoutes by dependencies
 
     routing {
         authenticate("admin") {
@@ -26,6 +28,7 @@ fun Application.configureRouting() {
             authorRoutes.get()
             authorRoutes.searchBooks()
             ownerRoutes.list()
+            eventRoutes.list()
         }
     }
 }

--- a/spektor-sample/src/main/resources/openapi/api/event.yaml
+++ b/spektor-sample/src/main/resources/openapi/api/event.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.1
+info:
+  title: Event API
+  version: 1.0.0
+paths:
+  /event:
+    get:
+      tags:
+        - Event
+      operationId: list
+      responses:
+        200:
+          description: List is returned
+          content:
+            application/json:
+              schema:
+                $ref: '../models/event.yaml#/components/schemas/EventsList'

--- a/spektor-sample/src/main/resources/openapi/models/event.yaml
+++ b/spektor-sample/src/main/resources/openapi/models/event.yaml
@@ -1,0 +1,45 @@
+openapi: 3.0.1
+info:
+  title: Event Models
+  version: 1.0.0
+paths: { }
+components:
+  schemas:
+    Event:
+      oneOf:
+        - $ref: '#/components/schemas/ClickEvent'
+        - $ref: '#/components/schemas/PingEvent'
+      discriminator:
+        propertyName: type
+        mapping:
+          CLICK: '#/components/schemas/ClickEvent'
+          PING: '#/components/schemas/PingEvent'
+    ClickEvent:
+      type: object
+      properties:
+        type:
+          type: string
+        x:
+          type: integer
+        y:
+          type: integer
+      required:
+        - type
+        - x
+        - y
+    PingEvent:
+      type: object
+      properties:
+        type:
+          type: string
+      required:
+        - type
+    EventsList:
+      type: object
+      properties:
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/Event'
+      required:
+        - events

--- a/spektor-sample/src/test/kotlin/io/github/vooft/spektor/EventTest.kt
+++ b/spektor-sample/src/test/kotlin/io/github/vooft/spektor/EventTest.kt
@@ -1,0 +1,76 @@
+package io.github.vooft.spektor
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import spektor.example.models.event.EventDto
+import spektor.example.models.event.EventsListDto
+
+class EventTest {
+
+    @Test
+    fun `should list events with empty object variant`() = testClient("admin") { client ->
+        val response = client.get("/event")
+        response.status shouldBe HttpStatusCode.OK
+
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        val events = body["events"].shouldNotBeNull().jsonArray
+        events shouldHaveSize 2
+
+        val click = events.first { it.jsonObject["type"].shouldNotBeNull().jsonPrimitive.content == "CLICK" }.jsonObject
+        click["x"].shouldNotBeNull().jsonPrimitive.content shouldBe "10"
+        click["y"].shouldNotBeNull().jsonPrimitive.content shouldBe "20"
+
+        val ping = events.first { it.jsonObject["type"].shouldNotBeNull().jsonPrimitive.content == "PING" }.jsonObject
+        ping.keys shouldBe setOf("type")
+    }
+
+    @Test
+    fun `should deserialize events into sealed hierarchy`() = testClient("admin") { client ->
+        val response = client.get("/event")
+        response.status shouldBe HttpStatusCode.OK
+
+        val eventsList = Json.decodeFromString<EventsListDto>(response.bodyAsText())
+        eventsList.events shouldHaveSize 2
+
+        val click = eventsList.events.filterIsInstance<EventDto.ClickEventDto>().single()
+        click.x shouldBe 10
+        click.y shouldBe 20
+
+        val ping = eventsList.events.filterIsInstance<EventDto.PingEventDto>().single()
+        ping shouldBe EventDto.PingEventDto
+    }
+
+    @Test
+    fun `should serialize PingEvent as object with only discriminator`() {
+        val json = Json.encodeToString(EventsListDto(events = listOf(EventDto.PingEventDto)))
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        val events = parsed["events"].shouldNotBeNull().jsonArray
+        events shouldHaveSize 1
+
+        val ping = events.single().jsonObject
+        ping.keys shouldBe setOf("type")
+        ping["type"].shouldNotBeNull().jsonPrimitive.content shouldBe "PING"
+    }
+
+    @Test
+    fun `should round-trip serialize and deserialize ClickEvent`() {
+        val original = EventsListDto(events = listOf(EventDto.ClickEventDto(x = 42, y = 99)))
+        val json = Json.encodeToString(original)
+        val deserialized = Json.decodeFromString<EventsListDto>(json)
+
+        deserialized.events shouldHaveSize 1
+        val click = deserialized.events.single().shouldBeInstanceOf<EventDto.ClickEventDto>()
+        click.x shouldBe 42
+        click.y shouldBe 99
+    }
+}


### PR DESCRIPTION
Problem: When a oneOf variant has no properties besides the discriminator, Spektor generated an empty data class, which is invalid Kotlin.

