### PR TITLE
Fix nested map codegen

### DIFF
--- a/spektor-lib/spektor-codegen/src/main/kotlin/io/github/vooft/spektor/codegen/codegen/SpektorTypeCodegen.kt
+++ b/spektor-lib/spektor-codegen/src/main/kotlin/io/github/vooft/spektor/codegen/codegen/SpektorTypeCodegen.kt
@@ -74,12 +74,14 @@ class SpektorTypeCodegen(
     }
 
     private fun validatePropertyNamesKeyType(keyType: SpektorType) {
-        require(keyType is SpektorType.Ref) {
-            "propertyNames key must be a \$ref to a string-based type, but got $keyType"
+        require(keyType is SpektorType.Ref || keyType is SpektorType.MicroType.StringMicroType) {
+            "propertyNames key must be a string-based type or a \$ref to one, but got $keyType"
         }
-        val target = context.refs.getValue(keyType.traceRefs().last())
-        require(target is SpektorType.MicroType.StringMicroType || target is SpektorType.Enum) {
-            "propertyNames key \$ref $keyType must resolve to a string-based type, but resolves to $target"
+        if (keyType is SpektorType.Ref) {
+            val target = context.refs.getValue(keyType.traceRefs().last())
+            require(target is SpektorType.MicroType.StringMicroType || target is SpektorType.Enum) {
+                "propertyNames key \$ref $keyType must resolve to a string-based type, but resolves to $target"
+            }
         }
     }
 

--- a/spektor-lib/spektor-codegen/src/test/kotlin/io/github/vooft/spektor/codegen/SpektorCodegenAdditionalPropertiesTest.kt
+++ b/spektor-lib/spektor-codegen/src/test/kotlin/io/github/vooft/spektor/codegen/SpektorCodegenAdditionalPropertiesTest.kt
@@ -1,0 +1,30 @@
+package io.github.vooft.spektor.codegen
+
+import io.github.vooft.spektor.codegen.codegen.SpektorTypeCodegen
+import io.github.vooft.spektor.codegen.common.SpektorCodegenConfig
+import io.github.vooft.spektor.parser.SpektorParser
+import io.github.vooft.spektor.test.TestFiles.plainPricesApiFile
+import io.github.vooft.spektor.test.TestFiles.rootPath
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class SpektorCodegenAdditionalPropertiesTest {
+
+    private val parser = SpektorParser()
+    private val config = SpektorCodegenConfig(
+        basePackage = "io.github.vooft.spektor.example",
+        specRoot = rootPath,
+    )
+
+    @Test
+    fun `should generate Map with String key for additionalProperties without propertyNames`() {
+        val schema = parser.parse(listOf(plainPricesApiFile))
+        val context = SpektorCodegenContext(schema.paths, schema.refs)
+        val typeCodegen = SpektorTypeCodegen(config, context)
+
+        val plainPricesRef = schema.refs.keys.single { it.modelName == "PlainPrices" }
+        val generated = typeCodegen.generate(plainPricesRef)
+
+        generated.toString() shouldBe "kotlin.collections.Map<kotlin.String, io.github.vooft.spektor.example.models.money.MoneyDto>"
+    }
+}

--- a/spektor-lib/spektor-testdata/src/main/kotlin/io/github/vooft/spektor/test/TestFiles.kt
+++ b/spektor-lib/spektor-testdata/src/main/kotlin/io/github/vooft/spektor/test/TestFiles.kt
@@ -18,6 +18,7 @@ object TestFiles {
     val pathParamRefFile: Path = rootPath.resolve("api/path-param-ref.yaml")
     val queryParamRefFile: Path = rootPath.resolve("api/query-param-ref.yaml")
     val listOwnerFile: Path = rootPath.resolve("api/list-owner.yaml")
+    val plainPricesApiFile: Path = rootPath.resolve("api/plain-prices.yaml")
 
     /**
      * Models
@@ -27,6 +28,7 @@ object TestFiles {
     val moneyModelFile: Path = rootPath.resolve("models/money.yaml")
     val countryModelFile: Path = rootPath.resolve("models/country.yaml")
     val countryPricesModelFile: Path = rootPath.resolve("models/country-prices.yaml")
+    val plainPricesModelFile: Path = rootPath.resolve("models/plain-prices.yaml")
     val ownerModelFile: Path = rootPath.resolve("models/owner.yaml")
     val listEventFile: Path = rootPath.resolve("api/list-event.yaml")
     val eventModelFile: Path = rootPath.resolve("models/event.yaml")

--- a/spektor-lib/spektor-testdata/src/test/resources/api/plain-prices.yaml
+++ b/spektor-lib/spektor-testdata/src/test/resources/api/plain-prices.yaml
@@ -1,0 +1,17 @@
+openapi: 3.1.0
+info:
+  title: Plain Prices API
+  version: 1.0.0
+paths:
+  /plain-prices:
+    get:
+      tags:
+        - PlainPrices
+      operationId: getPlainPrices
+      responses:
+        200:
+          description: Plain prices are returned
+          content:
+            application/json:
+              schema:
+                $ref: '../models/plain-prices.yaml#/components/schemas/PlainPrices'

--- a/spektor-lib/spektor-testdata/src/test/resources/models/plain-prices.yaml
+++ b/spektor-lib/spektor-testdata/src/test/resources/models/plain-prices.yaml
@@ -1,0 +1,11 @@
+openapi: 3.1.0
+info:
+  title: Plain Prices Models
+  version: 1.0.0
+paths: { }
+components:
+  schemas:
+    PlainPrices:
+      type: object
+      additionalProperties:
+        $ref: "./money.yaml#/components/schemas/Money"

--- a/spektor-sample/build.gradle.kts
+++ b/spektor-sample/build.gradle.kts
@@ -81,11 +81,12 @@ listOf(
     "src/main/resources/openapi/api/book.yaml",
     "src/main/resources/openapi/api/owner.yaml",
     "src/main/resources/openapi/api/event.yaml",
+    "src/main/resources/openapi/api/notification.yaml",
 ).forEachIndexed { index, specPath ->
     val taskName = "generateTestClientOpenApi$index"
     tasks.register<GenerateTask>(taskName) {
         generatorName.set("kotlin")
-        library.set("multiplatform")
+        library.set("jvm-ktor")
         skipOverwrite.set(true)
 
         inputSpec.set(file(specPath).absolutePath)
@@ -99,6 +100,7 @@ listOf(
             mapOf(
                 "dateLibrary" to "kotlinx-datetime",
                 "generateOneOfAnyOfWrappers" to "true",
+                "serializationLibrary" to "kotlinx_serialization",
             )
         )
 
@@ -138,4 +140,4 @@ listOf(
     }
 }
 
-kotlin.sourceSets["test"].kotlin.srcDir("${layout.buildDirectory.get().asFile.absolutePath}/test-generated/src/commonMain/kotlin")
+kotlin.sourceSets["test"].kotlin.srcDir("${layout.buildDirectory.get().asFile.absolutePath}/test-generated/src/main/kotlin")

--- a/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/apis/NotificationRestService.kt
+++ b/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/apis/NotificationRestService.kt
@@ -1,0 +1,21 @@
+package io.github.vooft.spektor.sample.apis
+
+import io.ktor.server.application.ApplicationCall
+import spektor.example.api.notification.NotificationServerApi
+import spektor.example.api.notification.NotificationServerApi.GetSettingsResponse
+import spektor.example.models.notification.NotificationCategoryDto
+
+class NotificationRestService : NotificationServerApi {
+    private val settings: Map<String, Map<NotificationCategoryDto, Boolean>> = mapOf(
+        "PUSH" to mapOf(
+            NotificationCategoryDto.CARD_PAYMENT to true,
+            NotificationCategoryDto.REWARDS to true,
+        ),
+        "SMS" to mapOf(
+            NotificationCategoryDto.CARD_PAYMENT to true,
+            NotificationCategoryDto.REWARDS to false,
+        ),
+    )
+
+    override suspend fun getSettings(call: ApplicationCall): GetSettingsResponse = GetSettingsResponse.ok(settings)
+}

--- a/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/ktor/DependencyInjection.kt
+++ b/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/ktor/DependencyInjection.kt
@@ -3,6 +3,7 @@ package io.github.vooft.spektor.sample.ktor
 import io.github.vooft.spektor.sample.apis.AuthorRestService
 import io.github.vooft.spektor.sample.apis.BookRestService
 import io.github.vooft.spektor.sample.apis.EventRestService
+import io.github.vooft.spektor.sample.apis.NotificationRestService
 import io.github.vooft.spektor.sample.apis.OwnerRestService
 import io.github.vooft.spektor.sample.repository.AuthorRepository
 import io.github.vooft.spektor.sample.repository.BookRepository
@@ -11,6 +12,7 @@ import io.ktor.server.plugins.di.dependencies
 import spektor.example.api.author.AuthorRoutes
 import spektor.example.api.book.BookRoutes
 import spektor.example.api.event.EventRoutes
+import spektor.example.api.notification.NotificationRoutes
 import spektor.example.api.owner.OwnerRoutes
 
 fun Application.configureDependencyInjection() {
@@ -22,10 +24,12 @@ fun Application.configureDependencyInjection() {
         provide { BookRestService(resolve(), resolve()) }
         provide { OwnerRestService() }
         provide { EventRestService() }
+        provide { NotificationRestService() }
 
         provide { AuthorRoutes(resolve()) }
         provide { BookRoutes(resolve()) }
         provide { OwnerRoutes(resolve()) }
         provide { EventRoutes(resolve()) }
+        provide { NotificationRoutes(resolve()) }
     }
 }

--- a/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/ktor/Routing.kt
+++ b/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/ktor/Routing.kt
@@ -7,6 +7,7 @@ import io.ktor.server.routing.routing
 import spektor.example.api.author.AuthorRoutes
 import spektor.example.api.book.BookRoutes
 import spektor.example.api.event.EventRoutes
+import spektor.example.api.notification.NotificationRoutes
 import spektor.example.api.owner.OwnerRoutes
 
 fun Application.configureRouting() {
@@ -14,6 +15,7 @@ fun Application.configureRouting() {
     val bookRoutes: BookRoutes by dependencies
     val ownerRoutes: OwnerRoutes by dependencies
     val eventRoutes: EventRoutes by dependencies
+    val notificationRoutes: NotificationRoutes by dependencies
 
     routing {
         authenticate("admin") {
@@ -29,6 +31,7 @@ fun Application.configureRouting() {
             authorRoutes.searchBooks()
             ownerRoutes.list()
             eventRoutes.list()
+            notificationRoutes.getSettings()
         }
     }
 }

--- a/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/ktor/Serialization.kt
+++ b/spektor-sample/src/main/kotlin/io/github/vooft/spektor/sample/ktor/Serialization.kt
@@ -22,49 +22,51 @@ fun Application.configureSerialization() {
     install(ContentNegotiation) {
         json(
             Json {
-                serializersModule = SerializersModule {
-                    contextual(
-                        kClass = Instant::class,
-                        serializer = object : KSerializer<Instant> {
-                            override val descriptor = PrimitiveSerialDescriptor("Instant", PrimitiveKind.STRING)
-                            override fun serialize(encoder: Encoder, value: Instant) = encoder.encodeString(value.toString())
-                            override fun deserialize(decoder: Decoder): Instant = Instant.parse(decoder.decodeString())
-                        }
-                    )
-                    contextual(
-                        kClass = LocalDate::class,
-                        serializer = object : KSerializer<LocalDate> {
-                            override val descriptor = PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
-                            override fun serialize(encoder: Encoder, value: LocalDate) = encoder.encodeString(value.toString())
-                            override fun deserialize(decoder: Decoder): LocalDate = LocalDate.parse(decoder.decodeString())
-                        }
-                    )
-                    contextual(
-                        kClass = YearMonth::class,
-                        serializer = object : KSerializer<YearMonth> {
-                            override val descriptor = PrimitiveSerialDescriptor("YearMonth", PrimitiveKind.STRING)
-                            override fun serialize(encoder: Encoder, value: YearMonth) = encoder.encodeString(value.toString())
-                            override fun deserialize(decoder: Decoder): YearMonth = YearMonth.parse(decoder.decodeString())
-                        }
-                    )
-                    contextual(
-                        kClass = UUID::class,
-                        serializer = object : KSerializer<UUID> {
-                            override val descriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
-                            override fun serialize(encoder: Encoder, value: UUID) = encoder.encodeString(value.toString())
-                            override fun deserialize(decoder: Decoder): UUID = UUID.fromString(decoder.decodeString())
-                        }
-                    )
-                    contextual(
-                        kClass = URI::class,
-                        serializer = object : KSerializer<URI> {
-                            override val descriptor = PrimitiveSerialDescriptor("URI", STRING)
-                            override fun deserialize(decoder: Decoder): URI = URI(decoder.decodeString())
-                            override fun serialize(encoder: Encoder, value: URI) = encoder.encodeString(value.toString())
-                        }
-                    )
-                }
+                serializersModule = serializersModule()
             }
         )
     }
+}
+
+fun serializersModule() = SerializersModule {
+    contextual(
+        kClass = Instant::class,
+        serializer = object : KSerializer<Instant> {
+            override val descriptor = PrimitiveSerialDescriptor("Instant", PrimitiveKind.STRING)
+            override fun serialize(encoder: Encoder, value: Instant) = encoder.encodeString(value.toString())
+            override fun deserialize(decoder: Decoder): Instant = Instant.parse(decoder.decodeString())
+        }
+    )
+    contextual(
+        kClass = LocalDate::class,
+        serializer = object : KSerializer<LocalDate> {
+            override val descriptor = PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
+            override fun serialize(encoder: Encoder, value: LocalDate) = encoder.encodeString(value.toString())
+            override fun deserialize(decoder: Decoder): LocalDate = LocalDate.parse(decoder.decodeString())
+        }
+    )
+    contextual(
+        kClass = YearMonth::class,
+        serializer = object : KSerializer<YearMonth> {
+            override val descriptor = PrimitiveSerialDescriptor("YearMonth", PrimitiveKind.STRING)
+            override fun serialize(encoder: Encoder, value: YearMonth) = encoder.encodeString(value.toString())
+            override fun deserialize(decoder: Decoder): YearMonth = YearMonth.parse(decoder.decodeString())
+        }
+    )
+    contextual(
+        kClass = UUID::class,
+        serializer = object : KSerializer<UUID> {
+            override val descriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+            override fun serialize(encoder: Encoder, value: UUID) = encoder.encodeString(value.toString())
+            override fun deserialize(decoder: Decoder): UUID = UUID.fromString(decoder.decodeString())
+        }
+    )
+    contextual(
+        kClass = URI::class,
+        serializer = object : KSerializer<URI> {
+            override val descriptor = PrimitiveSerialDescriptor("URI", STRING)
+            override fun deserialize(decoder: Decoder): URI = URI(decoder.decodeString())
+            override fun serialize(encoder: Encoder, value: URI) = encoder.encodeString(value.toString())
+        }
+    )
 }

--- a/spektor-sample/src/main/resources/openapi/api/notification.yaml
+++ b/spektor-sample/src/main/resources/openapi/api/notification.yaml
@@ -1,0 +1,17 @@
+openapi: 3.1.0
+info:
+  title: Notification API
+  version: 1.0.0
+paths:
+  /notification/settings:
+    get:
+      tags:
+        - Notification
+      operationId: getSettings
+      responses:
+        200:
+          description: Notification settings are returned
+          content:
+            application/json:
+              schema:
+                $ref: '../models/notification.yaml#/components/schemas/NotificationSettings'

--- a/spektor-sample/src/main/resources/openapi/models/notification.yaml
+++ b/spektor-sample/src/main/resources/openapi/models/notification.yaml
@@ -1,0 +1,34 @@
+openapi: 3.1.0
+info:
+  title: Notification Models
+  version: 1.0.0
+paths: { }
+components:
+  schemas:
+    NotificationChannel:
+      description: Notification Channel
+      type: string
+      enum:
+        - PUSH
+        - SMS
+    NotificationCategory:
+      description: Notification Category
+      type: string
+      enum:
+        - CARD_PAYMENT
+        - REWARDS
+    NotificationCategories:
+      description: Notification Categories
+      type: object
+      propertyNames:
+        $ref: '#/components/schemas/NotificationCategory'
+      additionalProperties:
+        type: boolean
+    NotificationSettings:
+      description: Notification Settings
+      type: object
+      #propertyNames skipped intentionally to test the default value
+      additionalProperties:
+        $ref: '#/components/schemas/NotificationCategories'
+
+

--- a/spektor-sample/src/test/kotlin/io/github/vooft/spektor/AuthorTest.kt
+++ b/spektor-sample/src/test/kotlin/io/github/vooft/spektor/AuthorTest.kt
@@ -1,11 +1,10 @@
 package io.github.vooft.spektor
 
-import io.github.vooft.spektor.test.apis.AuthorTestApi
-import io.github.vooft.spektor.test.infrastructure.ApiClient
 import io.github.vooft.spektor.test.models.AuthorRequestTestDto
 import io.github.vooft.spektor.test.models.CountryTestDto
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -15,13 +14,11 @@ import java.util.concurrent.ThreadLocalRandom
 
 class AuthorTest {
     @Test
-    fun `should create author`() = testClient("admin") { client ->
-        val api = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
+    fun `should create author`() = testClient("admin") {
         val name = UUID.randomUUID().toString()
         val dob = LocalDate.fromEpochDays(ThreadLocalRandom.current().nextInt(1000))
         val dod = LocalDate.fromEpochDays(ThreadLocalRandom.current().nextInt(1000))
-        val response = api.create(
+        val response = api.author.create(
             AuthorRequestTestDto(
                 name = name,
                 dateOfBirth = dob,
@@ -43,10 +40,8 @@ class AuthorTest {
     }
 
     @Test
-    fun `should fail to create author with 401`() = testClient("not admin") { client ->
-        val api = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val response = api.create(
+    fun `should fail to create author with 401`() = testClient("not admin") {
+        val response = api.author.create(
             AuthorRequestTestDto(
                 name = "test",
                 country = CountryTestDto.US,
@@ -58,19 +53,15 @@ class AuthorTest {
     }
 
     @Test
-    fun `should fail to get author with invalid id`() = testClient("admin") { client ->
-        val api = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
+    fun `should fail to get author with invalid id`() = testClient("admin") {
+        val response = client.get("/author/not-a-valid-uuid")
 
-        val response = api.get("not-a-valid-uuid")
-
-        response.status shouldBe 400
+        response.status.value shouldBe 400
     }
 
     @Test
-    fun `should list authors for countries`() = testClient("admin") { client ->
-        val api = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        api.create(
+    fun `should list authors for countries`() = testClient("admin") {
+        api.author.create(
             AuthorRequestTestDto(
                 name = UUID.randomUUID().toString(),
                 dateOfBirth = LocalDate.fromEpochDays(ThreadLocalRandom.current().nextInt(1000)),
@@ -79,7 +70,7 @@ class AuthorTest {
             )
         )
 
-        api.create(
+        api.author.create(
             AuthorRequestTestDto(
                 name = UUID.randomUUID().toString(),
                 dateOfBirth = LocalDate.fromEpochDays(ThreadLocalRandom.current().nextInt(1000)),
@@ -88,7 +79,7 @@ class AuthorTest {
             )
         )
 
-        api.create(
+        api.author.create(
             AuthorRequestTestDto(
                 name = UUID.randomUUID().toString(),
                 dateOfBirth = LocalDate.fromEpochDays(ThreadLocalRandom.current().nextInt(1000)),
@@ -97,7 +88,7 @@ class AuthorTest {
             )
         )
 
-        val response = api.list(countries = listOf(CountryTestDto.US, CountryTestDto.JP))
+        val response = api.author.list(countries = listOf(CountryTestDto.US, CountryTestDto.JP))
 
         response.status shouldBe 200
 

--- a/spektor-sample/src/test/kotlin/io/github/vooft/spektor/BookTest.kt
+++ b/spektor-sample/src/test/kotlin/io/github/vooft/spektor/BookTest.kt
@@ -1,8 +1,5 @@
 package io.github.vooft.spektor
 
-import io.github.vooft.spektor.test.apis.AuthorTestApi
-import io.github.vooft.spektor.test.apis.BookTestApi
-import io.github.vooft.spektor.test.infrastructure.ApiClient
 import io.github.vooft.spektor.test.models.AuthorRequestTestDto
 import io.github.vooft.spektor.test.models.BookRequestTestDto
 import io.github.vooft.spektor.test.models.CountryTestDto
@@ -23,10 +20,8 @@ import java.util.concurrent.ThreadLocalRandom
 
 class BookTest {
     @Test
-    fun `should create book`() = testClient("admin") { client ->
-        val api = BookTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val authorId = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client).create(
+    fun `should create book`() = testClient("admin") {
+        val authorId = api.author.create(
             AuthorRequestTestDto(
                 name = "test",
                 country = CountryTestDto.JP,
@@ -37,7 +32,7 @@ class BookTest {
         val title = UUID.randomUUID().toString()
         val minorUnits = ThreadLocalRandom.current().nextInt(1000)
         val currency = "USD"
-        val response = api.create(
+        val response = api.book.create(
             BookRequestTestDto(
                 title = title,
                 authorId = authorId,
@@ -59,10 +54,8 @@ class BookTest {
     }
 
     @Test
-    fun `should create book with countryPrices`() = testClient("admin") { client ->
-        val api = BookTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val authorId = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client).create(
+    fun `should create book with countryPrices`() = testClient("admin") {
+        val authorId = api.author.create(
             AuthorRequestTestDto(
                 name = "test",
                 country = CountryTestDto.JP,
@@ -75,7 +68,7 @@ class BookTest {
             "US" to MoneyTestDto(minorUnits = 999, currency = "USD"),
             "DE" to MoneyTestDto(minorUnits = 899, currency = "EUR"),
         )
-        val response = api.create(
+        val response = api.book.create(
             BookRequestTestDto(
                 title = title,
                 authorId = authorId,
@@ -91,10 +84,8 @@ class BookTest {
     }
 
     @Test
-    fun `should create book without countryPrices`() = testClient("admin") { client ->
-        val api = BookTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val authorId = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client).create(
+    fun `should create book without countryPrices`() = testClient("admin") {
+        val authorId = api.author.create(
             AuthorRequestTestDto(
                 name = "test",
                 country = CountryTestDto.JP,
@@ -103,7 +94,7 @@ class BookTest {
         ).body().id
 
         val title = UUID.randomUUID().toString()
-        val response = api.create(
+        val response = api.book.create(
             BookRequestTestDto(
                 title = title,
                 authorId = authorId,
@@ -118,8 +109,8 @@ class BookTest {
     }
 
     @Test
-    fun `should create book with metadata`() = testClient("admin") { client ->
-        val authorId = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client).create(
+    fun `should create book with metadata`() = testClient("admin") {
+        val authorId = api.author.create(
             AuthorRequestTestDto(
                 name = "test",
                 country = CountryTestDto.JP,
@@ -142,10 +133,8 @@ class BookTest {
     }
 
     @Test
-    fun `should create book without metadata`() = testClient("admin") { client ->
-        val api = BookTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val authorId = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client).create(
+    fun `should create book without metadata`() = testClient("admin") {
+        val authorId = api.author.create(
             AuthorRequestTestDto(
                 name = "test",
                 country = CountryTestDto.JP,
@@ -153,7 +142,7 @@ class BookTest {
             )
         ).body().id
 
-        val response = api.create(
+        val response = api.book.create(
             BookRequestTestDto(
                 title = UUID.randomUUID().toString(),
                 authorId = authorId,
@@ -165,10 +154,8 @@ class BookTest {
     }
 
     @Test
-    fun `should delete book`() = testClient("admin") { client ->
-        val api = BookTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val authorId = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client).create(
+    fun `should delete book`() = testClient("admin") {
+        val authorId = api.author.create(
             AuthorRequestTestDto(
                 name = "test",
                 country = CountryTestDto.JP,
@@ -176,22 +163,20 @@ class BookTest {
             )
         ).body().id
 
-        val bookId = api.create(
+        val bookId = api.book.create(
             BookRequestTestDto(
                 title = UUID.randomUUID().toString(),
                 authorId = authorId,
             )
         ).body().id
 
-        val response = api.delete(bookId)
+        val response = api.book.delete(bookId)
         response.status shouldBe 204
     }
 
     @Test
-    fun `should update book with body`() = testClient("admin") { client ->
-        val api = BookTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val authorId = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client).create(
+    fun `should update book with body`() = testClient("admin") {
+        val authorId = api.author.create(
             AuthorRequestTestDto(
                 name = "test",
                 country = CountryTestDto.JP,
@@ -199,7 +184,7 @@ class BookTest {
             )
         ).body().id
 
-        val bookId = api.create(
+        val bookId = api.book.create(
             BookRequestTestDto(
                 title = "original title",
                 authorId = authorId,
@@ -215,10 +200,8 @@ class BookTest {
     }
 
     @Test
-    fun `should update book without body`() = testClient("admin") { client ->
-        val api = BookTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val authorId = AuthorTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client).create(
+    fun `should update book without body`() = testClient("admin") {
+        val authorId = api.author.create(
             AuthorRequestTestDto(
                 name = "test",
                 country = CountryTestDto.JP,
@@ -226,7 +209,7 @@ class BookTest {
             )
         ).body().id
 
-        val bookId = api.create(
+        val bookId = api.book.create(
             BookRequestTestDto(
                 title = "original title",
                 authorId = authorId,
@@ -239,13 +222,11 @@ class BookTest {
     }
 
     @Test
-    fun `should fail to create author with 401`() = testClient("not admin") { client ->
-        val api = BookTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val response = api.create(
+    fun `should fail to create author with 401`() = testClient("not admin") {
+        val response = api.book.create(
             BookRequestTestDto(
                 title = "test",
-                authorId = UUID.randomUUID().toString(),
+                authorId = UUID.randomUUID(),
             )
         )
 

--- a/spektor-sample/src/test/kotlin/io/github/vooft/spektor/EventTest.kt
+++ b/spektor-sample/src/test/kotlin/io/github/vooft/spektor/EventTest.kt
@@ -1,10 +1,7 @@
 package io.github.vooft.spektor
 
-import io.github.vooft.spektor.test.apis.EventTestApi
-import io.github.vooft.spektor.test.infrastructure.ApiClient
-import io.github.vooft.spektor.test.models.ClickEventTestDto
+import io.github.vooft.spektor.test.models.EventTestDto
 import io.github.vooft.spektor.test.models.EventTypeTestDto
-import io.github.vooft.spektor.test.models.PingEventTestDto
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
@@ -12,22 +9,20 @@ import org.junit.jupiter.api.Test
 class EventTest {
 
     @Test
-    fun `should list events`() = testClient("admin") { client ->
-        val api = EventTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val response = api.list()
+    fun `should list events`() = testClient("admin") {
+        val response = api.event.list()
         response.status shouldBe 200
 
         val events = response.body().events
         events shouldHaveSize 2
 
-        events.map { it.actualInstance }.filterIsInstance<ClickEventTestDto>().single().run {
+        events.filterIsInstance<EventTestDto.ClickTestDtoWrapper>().single().value.run {
             type shouldBe EventTypeTestDto.CLICK
             x shouldBe 10
             y shouldBe 20
         }
 
-        events.map { it.actualInstance }.filterIsInstance<PingEventTestDto>().single().run {
+        events.filterIsInstance<EventTestDto.PingTestDtoWrapper>().single().value.run {
             type shouldBe EventTypeTestDto.PING
         }
     }

--- a/spektor-sample/src/test/kotlin/io/github/vooft/spektor/NotificationTest.kt
+++ b/spektor-sample/src/test/kotlin/io/github/vooft/spektor/NotificationTest.kt
@@ -1,0 +1,25 @@
+package io.github.vooft.spektor
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class NotificationTest {
+
+    @Test
+    fun `should return notification settings`() = testClient("admin") {
+        val response = api.notification.getSettings()
+
+        response.status shouldBe 200
+
+        response.body() shouldBe mapOf(
+            "PUSH" to mapOf(
+                "CARD_PAYMENT" to true,
+                "REWARDS" to true,
+            ),
+            "SMS" to mapOf(
+                "CARD_PAYMENT" to true,
+                "REWARDS" to false,
+            ),
+        )
+    }
+}

--- a/spektor-sample/src/test/kotlin/io/github/vooft/spektor/OwnerTest.kt
+++ b/spektor-sample/src/test/kotlin/io/github/vooft/spektor/OwnerTest.kt
@@ -1,9 +1,6 @@
 package io.github.vooft.spektor
 
-import io.github.vooft.spektor.test.apis.OwnerTestApi
-import io.github.vooft.spektor.test.infrastructure.ApiClient
-import io.github.vooft.spektor.test.models.BusinessTestDto
-import io.github.vooft.spektor.test.models.IndividualTestDto
+import io.github.vooft.spektor.test.models.OwnerTestDto
 import io.github.vooft.spektor.test.models.OwnerTypeTestDto
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -12,23 +9,21 @@ import org.junit.jupiter.api.Test
 class OwnerTest {
 
     @Test
-    fun `should list owners`() = testClient("admin") { client ->
-        val api = OwnerTestApi(baseUrl = ApiClient.BASE_URL, httpClient = client)
-
-        val response = api.list()
+    fun `should list owners`() = testClient("admin") {
+        val response = api.owner.list()
 
         response.status shouldBe 200
 
         val owners = response.body().owners
         owners shouldHaveSize 2
 
-        owners.map { it.actualInstance }.filterIsInstance<IndividualTestDto>().single().run {
+        owners.filterIsInstance<OwnerTestDto.IndividualTestDtoWrapper>().single().value.run {
             type shouldBe OwnerTypeTestDto.INDIVIDUAL
             firstName shouldBe "John"
             lastName shouldBe "Doe"
         }
 
-        owners.map { it.actualInstance }.filterIsInstance<BusinessTestDto>().single().run {
+        owners.filterIsInstance<OwnerTestDto.BusinessTestDtoWrapper>().single().value.run {
             type shouldBe OwnerTypeTestDto.BUSINESS
             name shouldBe "Acme Corp"
         }

--- a/spektor-sample/src/test/kotlin/io/github/vooft/spektor/TestHelpers.kt
+++ b/spektor-sample/src/test/kotlin/io/github/vooft/spektor/TestHelpers.kt
@@ -1,29 +1,95 @@
 package io.github.vooft.spektor
 
+import io.github.vooft.spektor.sample.ktor.serializersModule
 import io.github.vooft.spektor.sample.module
+import io.github.vooft.spektor.test.apis.AuthorTestApi
+import io.github.vooft.spektor.test.apis.BookTestApi
+import io.github.vooft.spektor.test.apis.EventTestApi
+import io.github.vooft.spektor.test.apis.NotificationTestApi
+import io.github.vooft.spektor.test.apis.OwnerTestApi
+import io.github.vooft.spektor.test.infrastructure.ApiClient
 import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BasicAuthCredentials
 import io.ktor.client.plugins.auth.providers.basic
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
 
-fun testClient(username: String, block: suspend (HttpClient) -> Unit) = testApplication {
+fun testClient(username: String, block: suspend TestContext.() -> Unit) = testApplication {
     application { module() }
-    block(
-        createClient {
-            install(ContentNegotiation) {
-                json()
-            }
 
-            install(Auth) {
-                basic {
-                    credentials {
-                        BasicAuthCredentials(username = username, password = username)
-                    }
+    val configure: HttpClientConfig<*>.() -> Unit = {
+        install(ContentNegotiation) {
+            json(testJson)
+        }
+        install(Auth) {
+            basic {
+                credentials {
+                    BasicAuthCredentials(username = username, password = username)
                 }
             }
         }
+    }
+
+    val rawClient = createClient { configure() }
+
+    val ctx = TestContext(
+        client = rawClient,
+        api = Api(
+            engine = rawClient.engine,
+            apiConfig = { it.configure() },
+        )
     )
+
+    block(ctx)
+}
+
+class TestContext(
+    val client: HttpClient,
+    val api: Api,
+)
+
+class Api(
+    engine: HttpClientEngine,
+    apiConfig: (HttpClientConfig<*>) -> Unit,
+) {
+
+    val author: AuthorTestApi = AuthorTestApi(
+        baseUrl = ApiClient.BASE_URL,
+        httpClientEngine = engine,
+        httpClientConfig = apiConfig,
+    )
+
+    val book: BookTestApi = BookTestApi(
+        baseUrl = ApiClient.BASE_URL,
+        httpClientEngine = engine,
+        httpClientConfig = apiConfig,
+    )
+
+    val event: EventTestApi = EventTestApi(
+        baseUrl = ApiClient.BASE_URL,
+        httpClientEngine = engine,
+        httpClientConfig = apiConfig,
+    )
+
+    val notification: NotificationTestApi = NotificationTestApi(
+        baseUrl = ApiClient.BASE_URL,
+        httpClientEngine = engine,
+        httpClientConfig = apiConfig,
+    )
+
+    val owner: OwnerTestApi = OwnerTestApi(
+        baseUrl = ApiClient.BASE_URL,
+        httpClientEngine = engine,
+        httpClientConfig = apiConfig,
+    )
+}
+
+private val testJson = Json {
+    ignoreUnknownKeys = true
+    serializersModule = serializersModule()
 }


### PR DESCRIPTION
* supported map-of-map responses end-to-end (codegen + sample)
* migrated to jvm-ktor library: described why below                                                                                                                                                
                                         
Adding the Notification API to the sample introduced a getSettings response typed as NotificationSettings, where additionalProperties references NotificationCategories, which is itself a Map<NotificationCategory, Boolean>. In other words, the response is a map-of-map.                                                                                                                        
                                                                                                                                                                                                           
With the previous library = "multiplatform" setting, openapi-generator produced an unusable wrapper in NotificationTestApi.kt:                                                                           

```kotlin

  private class GetSettingsResponse(val value: Map<kotlin.String, kotlin.collections.Map>) {                                                                                                               
      private val serializer: KSerializer<Map<kotlin.String, kotlin.collections.Map>> =                                                                                                                    
          serializer<Map<String, kotlin.collections.Map>>()                                                                                                                                                
      ...                                                                                                                                                                                                  
  }  
``` 